### PR TITLE
feat(bulk-create): allow override of conflict keys in Model.bulkCreate

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2513,6 +2513,7 @@ class Model {
    * @param  {boolean}        [options.benchmark=false]        Pass query execution time in milliseconds as second argument to logging function (options.logging).
    * @param  {boolean|Array}  [options.returning=false]        If true, append RETURNING <model columns> to get back all defined values; if an array of column names, append RETURNING <columns> to get back specific columns (Postgres only)
    * @param  {string}         [options.searchPath=DEFAULT]     An optional parameter to specify the schema search_path (Postgres only)
+   * @param  {Array<string>}  [options.conflictFields]         Optimal override for the conflict fields in the ON CONFLICT part of the query. Only supported in Postgres >= 9.5 and SQLite >= 3.24.0
    *
    * @returns {Promise<Array<Model>>}
    */
@@ -2684,23 +2685,28 @@ class Model {
         if (options.updateOnDuplicate) {
           options.updateOnDuplicate = options.updateOnDuplicate.map(attr => model.rawAttributes[attr].field || attr);
 
-          const upsertKeys = [];
 
-          for (const i of model._indexes) {
-            if (i.unique && !i.where) { // Don't infer partial indexes
-              upsertKeys.push(...i.fields);
+          if (options.conflictFields) {
+            options.upsertKeys = options.conflictFields;
+          } else {
+            const upsertKeys = [];
+
+            for (const i of model._indexes) {
+              if (i.unique && !i.where) { // Don't infer partial indexes
+                upsertKeys.push(...i.fields);
+              }
             }
+
+            const firstUniqueKey = Object.values(model.uniqueKeys).find(c => c.fields.length > 0);
+
+            if (firstUniqueKey && firstUniqueKey.fields) {
+              upsertKeys.push(...firstUniqueKey.fields);
+            }
+
+            options.upsertKeys = upsertKeys.length > 0
+              ? upsertKeys
+              : Object.values(model.primaryKeys).map(x => x.field);
           }
-
-          const firstUniqueKey = Object.values(model.uniqueKeys).find(c => c.fields.length > 0);
-
-          if (firstUniqueKey && firstUniqueKey.fields) {
-            upsertKeys.push(...firstUniqueKey.fields);
-          }
-
-          options.upsertKeys = upsertKeys.length > 0
-            ? upsertKeys
-            : Object.values(model.primaryKeys).map(x => x.field);
         }
 
         // Map returning attributes to fields

--- a/test/unit/model/bulkcreate.test.js
+++ b/test/unit/model/bulkcreate.test.js
@@ -9,36 +9,57 @@ const chai = require('chai'),
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   describe('bulkCreate', () => {
-    before(function() {
-      this.Model = current.define('model', {
+    const Model = current.define(
+      'model',
+      {
         accountId: {
           type: DataTypes.INTEGER(11).UNSIGNED,
           allowNull: false,
           field: 'account_id'
         }
-      }, { timestamps: false });
+      },
+      { timestamps: false }
+    );
 
-      this.stub = sinon.stub(current.getQueryInterface(), 'bulkInsert').resolves([]);
+    const stub = sinon
+      .stub(current.getQueryInterface(), 'bulkInsert')
+      .resolves([]);
+
+    beforeEach(async () => {
+      await Model.sync({ force: true });
     });
 
-    afterEach(function() {
-      this.stub.resetHistory();
+    afterEach(() => {
+      stub.resetHistory();
     });
 
-    after(function() {
-      this.stub.restore();
+    after(() => {
+      stub.restore();
     });
 
     describe('validations', () => {
-      it('should not fail for renamed fields', async function() {
-        await this.Model.bulkCreate([
-          { accountId: 42 }
-        ], { validate: true });
+      it('should not fail for renamed fields', async () => {
+        await Model.bulkCreate([{ accountId: 42 }], { validate: true });
 
-        expect(this.stub.getCall(0).args[1]).to.deep.equal([
+        expect(stub.getCall(0).args[1]).to.deep.equal([
           { account_id: 42, id: null }
         ]);
       });
+
+      if (current.dialect.supports.inserts.updateOnDuplicate) {
+        it('should pass conflictFields directly as upsertKeys', async () => {
+          // Note that the model also has an id key as its primary key.
+          await Model.bulkCreate([{ accountId: 42 }], {
+            conflictFields: ['a', 'b', 'c'],
+            updateOnDuplicate: ['accountId'] // needed for conflictFields to be looked at.
+          }).catch(() => {});
+
+          expect(
+            // Not worth checking that the reference of the array matches - just the contents.
+            stub.getCall(0).args[2].upsertKeys
+          ).to.deep.equal(['a', 'b', 'c']);
+        });
+      }
     });
   });
 });

--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -775,6 +775,11 @@ export interface BulkCreateOptions<TAttributes = any> extends Logging, Transacti
    * Return all columns or only the specified columns for the affected rows (only for postgres)
    */
   returning?: boolean | (keyof TAttributes)[];
+  /**
+   * Optional override for the conflict fields in the ON CONFLICT part of the query.
+   * Only supported in Postgres >= 9.5 and SQLite >= 3.24.0
+  */
+  conflictFields?: (keyof TAttributes)[]
 }
 
 /**

--- a/types/test/bulkCreate.ts
+++ b/types/test/bulkCreate.ts
@@ -1,0 +1,81 @@
+import { DataTypes, Model, Optional } from 'sequelize';
+import { sequelize } from './connection';
+
+interface ITestModel {
+  id: number;
+  testString: string;
+  testEnum: 'd' | 'e' | 'f' | null;
+}
+
+interface ITestModelCreationArgs extends Omit<Optional<ITestModel, 'testString' | 'testEnum' | 'id'>, 'id'>{}
+
+class TestModel extends Model<
+  ITestModel,
+  ITestModelCreationArgs
+> {}
+
+TestModel.init(
+  {
+    id: { type: DataTypes.NUMBER },
+    testString: { type: DataTypes.STRING },
+    testEnum: { type: DataTypes.STRING },
+  },
+  { sequelize }
+);
+
+sequelize.transaction(async (trx) => {
+  const badItems: Array<ITestModelCreationArgs> = [{
+    // @ts-expect-error this isn't an enum value
+    testEnum: 'eafe'
+  }, {
+    // @ts-expect-error id isn't a creation arg (in this case, we assume that its set by the db and not here.)
+    id: 123
+  }, {
+    // @ts-expect-error testString should be a string or null
+    testString: 324
+  }]
+
+  const newItems: Array<ITestModelCreationArgs> = [{
+    testEnum: 'e',
+    testString: 'abc'
+  }, {
+    testEnum: null,
+    testString: undefined,
+  }]
+
+  const res1: Array<TestModel> = await TestModel.bulkCreate(
+    newItems,
+    {
+      benchmark: true,
+      fields: ['testEnum'],
+      hooks: true,
+      logging: true,
+      returning: true,
+      transaction: trx,
+      validate: true,
+      ignoreDuplicates: true,
+    }
+  );
+
+  const res2: Array<TestModel> = await TestModel.bulkCreate(
+    newItems,
+    {
+      benchmark: true,
+      fields: ['testEnum'],
+      hooks: true,
+      logging: true,
+      returning: false,
+      transaction: trx,
+      validate: true,
+      updateOnDuplicate: ['testEnum', 'testString']
+    }
+  );
+
+
+  const res3: Array<TestModel> = await TestModel.bulkCreate(
+    newItems,
+    {
+      conflictFields: ['testEnum', 'testString'],
+    }
+  );
+});


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

This is a copy of my pull request at https://github.com/sequelize/sequelize/pull/13419.

It's part 1/2 of what we (being replit) need for bulk upserts + partial indexes. (part 2 being #2)


### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

Allows for the override of the `upsertKeys` value passed to the query generator via `options.conflictFields` (for `Model.bulkCreate`).

Note that the different name is intentional - `upsertKeys` isn't as clear as `conflictFields` IMO.

This is a part of #13270 and it is needed for `conflictWhere` to work (properly at least) in some cases.  Though it is worth noting that there should be better logic for determining defaults, I think this is still handy for special edge cases.   

Example use case (using a many:many joiner table)
```ts
const Memberships: typeof Model = sequelize.define(
  'my_joiner_table',
  {
    id: {
      primaryKey: true,
      autoIncrement: true,
      type: DataTypes.INTEGER,
      allowNull: false,
    },
    group_id: {
      type: DataTypes.INTEGER,
      primaryKey: true,
      allowNull: false,
      // Note that the ideal way to make this relation is to have a unqiue partial index on `deletedAt IS NULL`
      // that way the unique constraint will ignore soft-deleted rows.
      // Once I make a PR similar to #13411 but for Model.bulkCreate though, that is what should be done. 
      unique: 'my_constraint',
    },
    user_id: {
      type: DataTypes.INTEGER,
      primaryKey: true,
      allowNull: false,
      unique: 'my_constraint',
    },
  },
  { timestamps: true }
);

// In usage
await Memberships.bulkCreate(
  [
    {
      group_id: 5,
      team_id: 3,
    },
    {
      group_id: 5,
      team_id: 4,
    },
  ],
  {
    conflictFields: ['group_id', 'user_id'],
  }
); // `ON CONFLICT ("group_id", "user_id")` instead of `ON CONFLICT ("id", "group_id", "user_id")` 

```
