### PR TITLE
feat(bulk-create): add conflictWhere option to Model.bulkCreate 

### DIFF
--- a/lib/dialects/abstract/index.js
+++ b/lib/dialects/abstract/index.js
@@ -39,7 +39,8 @@ AbstractDialect.prototype.supports = {
   inserts: {
     ignoreDuplicates: '', /* dialect specific words for INSERT IGNORE or DO NOTHING */
     updateOnDuplicate: false, /* whether dialect supports ON DUPLICATE KEY UPDATE */
-    onConflictDoNothing: '' /* dialect specific words for ON CONFLICT DO NOTHING */
+    onConflictDoNothing: '', /* dialect specific words for ON CONFLICT DO NOTHING */
+    onConflictWhere: false /* whether dialect supports ON CONFLICT WHERE  */
   },
   constraints: {
     restrict: true,

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -290,7 +290,19 @@ class QueryGenerator {
         // If no conflict target columns were specified, use the primary key names from options.upsertKeys
         const conflictKeys = options.upsertKeys.map(attr => this.quoteIdentifier(attr));
         const updateKeys = options.updateOnDuplicate.map(attr => `${this.quoteIdentifier(attr)}=EXCLUDED.${this.quoteIdentifier(attr)}`);
-        onDuplicateKeyUpdate = ` ON CONFLICT (${conflictKeys.join(',')}) DO UPDATE SET ${updateKeys.join(',')}`;
+
+        const hasConflictWhere = this._dialect.supports.inserts.onConflictWhere && options.conflictWhere;
+
+        // The Utils.joinSQLFragments later on will join this as it handles nested arrays.
+        onDuplicateKeyUpdate = [
+          'ON CONFLICT',
+          '(',
+          conflictKeys.join(','),
+          ')',
+          hasConflictWhere && this.whereQuery(options.conflictWhere, options),
+          'DO UPDATE SET',
+          updateKeys.join(',')
+        ];
       } else { // mysql / maria
         const valueKeys = options.updateOnDuplicate.map(attr => `${this.quoteIdentifier(attr)}=VALUES(${this.quoteIdentifier(attr)})`);
         onDuplicateKeyUpdate = `${this._dialect.supports.inserts.updateOnDuplicate} ${valueKeys.join(',')}`;

--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -46,7 +46,8 @@ PostgresDialect.prototype.supports = _.merge(_.cloneDeep(AbstractDialect.prototy
   },
   inserts: {
     onConflictDoNothing: ' ON CONFLICT DO NOTHING',
-    updateOnDuplicate: ' ON CONFLICT DO UPDATE SET'
+    updateOnDuplicate: ' ON CONFLICT DO UPDATE SET',
+    onConflictWhere: true
   },
   NUMERIC: true,
   ARRAY: true,

--- a/lib/dialects/sqlite/index.js
+++ b/lib/dialects/sqlite/index.js
@@ -29,7 +29,8 @@ SqliteDialect.prototype.supports = _.merge(_.cloneDeep(AbstractDialect.prototype
   'RIGHT JOIN': false,
   inserts: {
     ignoreDuplicates: ' OR IGNORE',
-    updateOnDuplicate: ' ON CONFLICT DO UPDATE SET'
+    updateOnDuplicate: ' ON CONFLICT DO UPDATE SET',
+    onConflictWhere: true
   },
   index: {
     using: false,

--- a/lib/model.js
+++ b/lib/model.js
@@ -2514,7 +2514,7 @@ class Model {
    * @param  {boolean|Array}  [options.returning=false]        If true, append RETURNING <model columns> to get back all defined values; if an array of column names, append RETURNING <columns> to get back specific columns (Postgres only)
    * @param  {string}         [options.searchPath=DEFAULT]     An optional parameter to specify the schema search_path (Postgres only)
    * @param  {Array<string>}  [options.conflictFields]         Optimal override for the conflict fields in the ON CONFLICT part of the query. Only supported in Postgres >= 9.5 and SQLite >= 3.24.0
-   * @param  {Array<string>}  [options.conflictWhere]          An optional paramater to specify a where clause for partial unique indexes (note: `ON CONFLICT WHERE` not `ON CONFLICT DO UPDATE WHERE`).  Only works in Postgres >= 9.5 and squlite >= 9.5
+   * @param  {Array<string>}  [options.conflictWhere]          An optional paramater to specify a where clause for partial unique indexes (note: `ON CONFLICT WHERE` not `ON CONFLICT DO UPDATE WHERE`).  Only works in Postgres >= 9.5 and sqlite >= 9.5
    * }
    * @returns {Promise<Array<Model>>}
    */

--- a/lib/model.js
+++ b/lib/model.js
@@ -2514,7 +2514,8 @@ class Model {
    * @param  {boolean|Array}  [options.returning=false]        If true, append RETURNING <model columns> to get back all defined values; if an array of column names, append RETURNING <columns> to get back specific columns (Postgres only)
    * @param  {string}         [options.searchPath=DEFAULT]     An optional parameter to specify the schema search_path (Postgres only)
    * @param  {Array<string>}  [options.conflictFields]         Optimal override for the conflict fields in the ON CONFLICT part of the query. Only supported in Postgres >= 9.5 and SQLite >= 3.24.0
-   *
+   * @param  {Array<string>}  [options.conflictWhere]          An optional paramater to specify a where clause for partial unique indexes (note: `ON CONFLICT WHERE` not `ON CONFLICT DO UPDATE WHERE`).  Only works in Postgres >= 9.5 and squlite >= 9.5
+   * }
    * @returns {Promise<Array<Model>>}
    */
   static async bulkCreate(records, options = {}) {

--- a/test/integration/model/bulk-create.test.js
+++ b/test/integration/model/bulk-create.test.js
@@ -760,10 +760,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           updateOnDuplicate: ['user_id', 'foreign_id', 'time_deleted']
         };
 
-        beforeEach(
-          async () =>
-            await Memberships.sync({ force: true })
-        );
+        beforeEach(() => Memberships.sync({ force: true }));
 
         it('should insert items with conflictWhere', async () => {
           const memberships = [...Array(10)].map((_, i) => ({

--- a/test/integration/model/bulk-create.test.js
+++ b/test/integration/model/bulk-create.test.js
@@ -726,6 +726,139 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
     }
 
+    if (
+      current.dialect.supports.inserts.onConflictWhere &&
+      current.dialect.supports.inserts.updateOnDuplicate
+    ) {
+      describe('conflictWhere', () => {
+        const Memberships = current.define(
+          'memberships',
+          {
+            // ID of the member (no foreign key constraint for testing purposes)
+            user_id: DataTypes.INTEGER,
+            // ID of what the member is a member of
+            foreign_id: DataTypes.INTEGER,
+            time_deleted: DataTypes.DATE
+          },
+          {
+            createdAt: false,
+            updatedAt: false,
+            deletedAt: 'time_deleted',
+            indexes: [
+              {
+                fields: ['user_id', 'foreign_id'],
+                unique: true,
+                where: { time_deleted: null }
+              }
+            ]
+          }
+        );
+
+        const options = {
+          conflictWhere: { time_deleted: null },
+          conflictFields: ['user_id', 'foreign_id'],
+          updateOnDuplicate: ['user_id', 'foreign_id', 'time_deleted']
+        };
+
+        beforeEach(
+          async () =>
+            await Memberships.sync({ force: true })
+        );
+
+        it('should insert items with conflictWhere', async () => {
+          const memberships = [...Array(10)].map((_, i) => ({
+            user_id: i + 1,
+            foreign_id: i + 20,
+            time_deleted: null
+          }));
+
+          const results = await Memberships.bulkCreate(memberships, options);
+
+          for (let i = 0; i < 10; i++) {
+            expect(results[i].user_id).to.eq(memberships[i].user_id);
+            expect(results[i].team_id).to.eq(memberships[i].team_id);
+            expect(results[i].time_deleted).to.eq(null);
+          }
+        });
+
+        it('should not conflict with soft deleted memberships', async () => {
+          const memberships = [...Array(10)].map((_, i) => ({
+            user_id: i + 1,
+            foreign_id: i + 20,
+            time_deleted: new Date()
+          }));
+
+          let results = await Memberships.bulkCreate(memberships, options);
+
+          for (let i = 0; i < 10; i++) {
+            expect(results[i].user_id).to.eq(memberships[i].user_id);
+            expect(results[i].team_id).to.eq(memberships[i].team_id);
+            expect(results[i].time_deleted).to.not.eq(null);
+          }
+
+          results = await Memberships.bulkCreate(
+            memberships.map(membership => ({
+              ...membership,
+              time_deleted: null
+            })),
+            options
+          );
+
+          for (let i = 0; i < 10; i++) {
+            expect(results[i].user_id).to.eq(memberships[i].user_id);
+            expect(results[i].team_id).to.eq(memberships[i].team_id);
+            expect(results[i].time_deleted).to.eq(null);
+          }
+
+          const count = await Memberships.count();
+
+          expect(count).to.eq(20);
+        });
+
+        it('should upsert existing memberships', async () => {
+          const memberships = [...Array(10)].map((_, i) => ({
+            user_id: i + 1,
+            foreign_id: i + 20,
+            time_deleted: i % 2 ? new Date() : null
+          }));
+
+          let results = await Memberships.bulkCreate(memberships, options);
+
+          for (let i = 0; i < 10; i++) {
+            expect(results[i].user_id).to.eq(memberships[i].user_id);
+            expect(results[i].team_id).to.eq(memberships[i].team_id);
+            if (i % 2) {
+              expect(results[i].time_deleted).to.not.eq(null);
+            } else {
+              expect(results[i].time_deleted).to.eq(null);
+            }
+          }
+
+          for (const membership of memberships) {
+            membership['time_deleted'];
+          }
+
+          results = await Memberships.bulkCreate(
+            memberships.map(membership => ({
+              ...membership,
+              time_deleted: null
+            })),
+            options
+          );
+
+          for (let i = 0; i < 10; i++) {
+            expect(results[i].user_id).to.eq(memberships[i].user_id);
+            expect(results[i].team_id).to.eq(memberships[i].team_id);
+            expect(results[i].time_deleted).to.eq(null);
+          }
+
+          const count = await Memberships.count({ paranoid: false });
+
+          expect(count).to.eq(15);
+        });
+      });
+    }
+
     if (current.dialect.supports.returnValues) {
       describe('return values', () => {
         it('should make the auto incremented values available on the returned instances', async function() {

--- a/test/unit/sql/insert.test.js
+++ b/test/unit/sql/insert.test.js
@@ -34,7 +34,6 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
           },
           bind: ['triggertest']
         });
-
     });
   });
 
@@ -161,5 +160,68 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
           sqlite: 'INSERT INTO `users` (`user_name`,`pass_word`) VALUES (\'testuser\',\'12345\') ON CONFLICT (`user_name`) DO UPDATE SET `user_name`=EXCLUDED.`user_name`,`pass_word`=EXCLUDED.`pass_word`,`updated_at`=EXCLUDED.`updated_at`;'
         });
     });
+
+    if (
+      current.dialect.supports.inserts.updateOnDuplicate &&
+      current.dialect.supports.inserts.onConflictWhere
+    ) {
+      it('correctly generates SQL for conflictWhere', () => {
+        const User = Support.sequelize.define('user', {
+          username: {
+            type: DataTypes.STRING,
+            field: 'user_name',
+            primaryKey: true
+          },
+          password: {
+            type: DataTypes.STRING,
+            field: 'pass_word'
+          },
+          createdAt: {
+            type: DataTypes.DATE,
+            field: 'created_at'
+          },
+          updatedAt: {
+            type: DataTypes.DATE,
+            field: 'updated_at'
+          },
+          deletedAt: {
+            type: DataTypes.DATE,
+            field: 'deleted_at'
+          }
+        }, {
+          timestamps: true
+        });
+
+        // mapping primary keys to their "field" override values
+        const primaryKeys = User.primaryKeyAttributes.map(attr => User.rawAttributes[attr].field || attr);
+
+        expectsql(
+          sql.bulkInsertQuery(
+            User.tableName,
+            [{ user_name: 'testuser', pass_word: '12345' }],
+            {
+              updateOnDuplicate: ['user_name', 'pass_word', 'updated_at'],
+              upsertKeys: primaryKeys,
+              conflictWhere: { deleted_at: null }
+            },
+            User.fieldRawAttributesMap
+          ),
+          {
+            default:
+              "INSERT INTO `users` (`user_name`,`pass_word`) VALUES ('testuser','12345');",
+            postgres:
+              'INSERT INTO "users" ("user_name","pass_word") VALUES (\'testuser\',\'12345\') ON CONFLICT ("user_name") WHERE "deleted_at" IS NULL DO UPDATE SET "user_name"=EXCLUDED."user_name","pass_word"=EXCLUDED."pass_word","updated_at"=EXCLUDED."updated_at";',
+            mssql:
+              "INSERT INTO [users] ([user_name],[pass_word]) VALUES (N'testuser',N'12345');",
+            mariadb:
+              "INSERT INTO `users` (`user_name`,`pass_word`) VALUES ('testuser','12345') ON DUPLICATE KEY UPDATE `user_name`=VALUES(`user_name`),`pass_word`=VALUES(`pass_word`),`updated_at`=VALUES(`updated_at`);",
+            mysql:
+              "INSERT INTO `users` (`user_name`,`pass_word`) VALUES ('testuser','12345') ON DUPLICATE KEY UPDATE `user_name`=VALUES(`user_name`),`pass_word`=VALUES(`pass_word`),`updated_at`=VALUES(`updated_at`);",
+            sqlite:
+              "INSERT INTO `users` (`user_name`,`pass_word`) VALUES ('testuser','12345') ON CONFLICT (`user_name`) WHERE `deleted_at` IS NULL DO UPDATE SET `user_name`=EXCLUDED.`user_name`,`pass_word`=EXCLUDED.`pass_word`,`updated_at`=EXCLUDED.`updated_at`;"
+          }
+        );
+      });
+    }
   });
 });


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

This is a copy of my pr on the main sequelize repo - https://github.com/sequelize/sequelize/pull/13420.

It's part 2/2 of what we (being replit) need for bulk upserts + partial indexes. (part 1: #1)

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

- Added the option `conflictWhere` to `QueryGenerator.prototype.bulkInsertQuery`.  This is used to generate the `ON CONFLICT WHERE` part of the query (note: not `ON CONFLICT DO UPDATE WHERE`).
- Added an option to `Model.bulkCreate`, `conflictWhere`. (rather: documented the option)
- Updated types
- Added tests

Note that this is based on #13419 - once that gets merged I'll rebase + remove that diff from this pr.

Example use case:
```js
const Memberships = sequelize.define(
  'memberships',
  {
    user_id: { type: DataTypes.INTEGER, allowNull: false },
    foreign_id: { type: DataTypes.INTEGER, allowNull: false },
    permissions: {
      type: DataTypes.ENUM('admin', 'member', 'guest'),
      allowNull: false,
    },
  },
  {
    deletedAt: 'time_deleted',
    indexes: [
      {
        fields: ['user_id', 'foreign_key'],
        unique: true,
        where: { time_deleted: null },
      },
    ],
  }
);

// In a single query, create (or update) the memberships of many users.
// Only update permissions if existing memberships exist.
Memberships.bulkCreate(
  [
    {
      user_id: 1,
      foreign_id: 1,
      permissions: 'admin',
    },
    {
      user_id: 2,
      foreign_id: 1,
      permissions: 'member',
    },
    {
      user_id: 3,
      foreign_id: 1,
      permissions: 'member',
    },
    {
      user_id: 4,
      foreign_id: 1,
      permissions: 'guest',
    },
  ],
  {
    conflictFields: ['user_id', 'foreign_id'],
    conflictWhere: { time_deleted: null },
    updateOnDuplicate: ['permissions'],
  }
);
```

The bulkCreate would end up looking similar to this (for postgres):

```sql
INSERT INTO
  "memberships" ("id", "user_id", "foreign_id", "permissions")
VALUES
  (DEFAULT, 1, 1, 'admin'),
  (DEFAULT, 2, 1, 'member'),
  (DEFAULT, 3, 1, 'member'),
  (DEFAULT, 4, 1, 'guest') ON CONFLICT ("user_id", "foreign_id")
WHERE
  "time_deleted" IS NULL DO
UPDATE
SET
  "user_id" = EXCLUDED. "user_id",
  "foreign_id" = EXCLUDED. "foreign_id";
```
