### PR TITLE
feat(upsert): allow override of conflict keys in Model.upsert

### DIFF
--- a/lib/dialects/abstract/query-interface.js
+++ b/lib/dialects/abstract/query-interface.js
@@ -767,39 +767,48 @@ class QueryInterface {
     options = { ...options };
 
     const model = options.model;
-    const primaryKeys = Object.values(model.primaryKeys).map(item => item.field);
-    const uniqueKeys = Object.values(model.uniqueKeys).filter(c => c.fields.length > 0).map(c => c.fields);
-    const indexKeys = Object.values(model._indexes).filter(c => c.unique && c.fields.length > 0).map(c => c.fields);
 
     options.type = QueryTypes.UPSERT;
     options.updateOnDuplicate = Object.keys(updateValues);
-    options.upsertKeys = [];
+    options.upsertKeys = options.conflictFields || [];
 
-    // For fields in updateValues, try to find a constraint or unique index
-    // that includes given field. Only first matching upsert key is used.
-    for (const field of options.updateOnDuplicate) {
-      const uniqueKey = uniqueKeys.find(fields => fields.includes(field));
-      if (uniqueKey) {
-        options.upsertKeys = uniqueKey;
-        break;
+    if (options.upsertKeys.length === 0) {
+      const primaryKeys = Object.values(model.primaryKeys).map(
+        item => item.field
+      );
+      const uniqueKeys = Object.values(model.uniqueKeys)
+        .filter(c => c.fields.length > 0)
+        .map(c => c.fields);
+      const indexKeys = Object.values(model._indexes)
+        .filter(c => c.unique && c.fields.length > 0)
+        .map(c => c.fields);
+
+      // For fields in updateValues, try to find a constraint or unique index
+      // that includes given field. Only first matching upsert key is used.
+      for (const field of options.updateOnDuplicate) {
+        const uniqueKey = uniqueKeys.find(fields => fields.includes(field));
+        if (uniqueKey) {
+          options.upsertKeys = uniqueKey;
+          break;
+        }
+
+        const indexKey = indexKeys.find(fields => fields.includes(field));
+        if (indexKey) {
+          options.upsertKeys = indexKey;
+          break;
+        }
       }
 
-      const indexKey = indexKeys.find(fields => fields.includes(field));
-      if (indexKey) {
-        options.upsertKeys = indexKey;
-        break;
+      // Always use PK, if no constraint available OR update data contains PK
+      if (
+        options.upsertKeys.length === 0 ||
+        _.intersection(options.updateOnDuplicate, primaryKeys).length
+      ) {
+        options.upsertKeys = primaryKeys;
       }
-    }
 
-    // Always use PK, if no constraint available OR update data contains PK
-    if (
-      options.upsertKeys.length === 0
-      || _.intersection(options.updateOnDuplicate, primaryKeys).length
-    ) {
-      options.upsertKeys = primaryKeys;
+      options.upsertKeys = _.uniq(options.upsertKeys);
     }
-
-    options.upsertKeys = _.uniq(options.upsertKeys);
 
     const sql = this.queryGenerator.insertQuery(tableName, insertValues, model.rawAttributes, options);
     return await this.sequelize.query(sql, options);

--- a/lib/model.js
+++ b/lib/model.js
@@ -2416,17 +2416,18 @@ class Model {
    *
    * **Note** that Postgres/SQLite returns null for created, no matter if the row was created or updated
    *
-   * @param  {object}       values                                        hash of values to upsert
-   * @param  {object}       [options]                                     upsert options
-   * @param  {boolean}      [options.validate=true]                       Run validations before the row is inserted
-   * @param  {Array}        [options.fields=Object.keys(this.attributes)] The fields to insert / update. Defaults to all changed fields
-   * @param  {boolean}      [options.hooks=true]                          Run before / after upsert hooks?
-   * @param  {boolean}      [options.returning=true]                      If true, fetches back auto generated values
-   * @param  {Transaction}  [options.transaction]                         Transaction to run query under
-   * @param  {Function}     [options.logging=false]                       A function that gets executed while running the query to log the sql.
-   * @param  {boolean}      [options.benchmark=false]                     Pass query execution time in milliseconds as second argument to logging function (options.logging).
-   * @param  {string}       [options.searchPath=DEFAULT]                  An optional parameter to specify the schema search_path (Postgres only)
-   * @param  {object}       [options.conflictWhere]                       An optional parameter that specifies a where clause for the `ON CONFLICT` part of the query (in particular: for applying to partial unique indexes). Only supported in Postgres >= 9.5 and SQLite >= 3.24.0.
+   * @param  {object}        values                                        hash of values to upsert
+   * @param  {object}        [options]                                     upsert options
+   * @param  {boolean}       [options.validate=true]                       Run validations before the row is inserted
+   * @param  {Array}         [options.fields=Object.keys(this.attributes)] The fields to insert / update. Defaults to all changed fields
+   * @param  {boolean}       [options.hooks=true]                          Run before / after upsert hooks?
+   * @param  {boolean}       [options.returning=true]                      If true, fetches back auto generated values
+   * @param  {Transaction}   [options.transaction]                         Transaction to run query under
+   * @param  {Function}      [options.logging=false]                       A function that gets executed while running the query to log the sql.
+   * @param  {boolean}       [options.benchmark=false]                     Pass query execution time in milliseconds as second argument to logging function (options.logging).
+   * @param  {string}        [options.searchPath=DEFAULT]                  An optional parameter to specify the schema search_path (Postgres only)
+   * @param  {Array<string>} [options.conflictFields]                      Optional override for the conflict fields in the ON CONFLICT part of the query. Only supported in Postgres >= 9.5 and SQLite >= 3.24.0
+   * @param  {object}        [options.conflictWhere]                       An optional parameter that specifies a where clause for the `ON CONFLICT` part of the query (in particular: for applying to partial unique indexes). Only supported in Postgres >= 9.5 and SQLite >= 3.24.0.
    *
    * @returns {Promise<[Model, boolean | null]>} returns an array with two elements, the first being the new record and the second being `true` if it was just created or `false` if it already existed (except on Postgres and SQLite, which can't detect this and will always return `null` instead of a boolean).
    */
@@ -2514,7 +2515,7 @@ class Model {
    * @param  {boolean}        [options.benchmark=false]        Pass query execution time in milliseconds as second argument to logging function (options.logging).
    * @param  {boolean|Array}  [options.returning=false]        If true, append RETURNING <model columns> to get back all defined values; if an array of column names, append RETURNING <columns> to get back specific columns (Postgres only)
    * @param  {string}         [options.searchPath=DEFAULT]     An optional parameter to specify the schema search_path (Postgres only)
-   * @param  {Array<string>}  [options.conflictFields]         Optimal override for the conflict fields in the ON CONFLICT part of the query. Only supported in Postgres >= 9.5 and SQLite >= 3.24.0
+   * @param  {Array<string>}  [options.conflictFields]         Optional override for the conflict fields in the ON CONFLICT part of the query. Only supported in Postgres >= 9.5 and SQLite >= 3.24.0
    * @param  {Array<string>}  [options.conflictWhere]          An optional paramater to specify a where clause for partial unique indexes (note: `ON CONFLICT WHERE` not `ON CONFLICT DO UPDATE WHERE`).  Only works in Postgres >= 9.5 and sqlite >= 9.5
    * }
    * @returns {Promise<Array<Model>>}

--- a/test/integration/model/upsert.test.js
+++ b/test/integration/model/upsert.test.js
@@ -601,6 +601,87 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
 
       if (current.dialect.supports.inserts.onConflictWhere) {
+        describe('conflictFields', () => {
+          // An Abstract joiner table.  Unique constraint deliberately removed
+          // to ensure that `conflictFields` is actually respected, not inferred.
+          const Memberships = current.define('memberships', {
+            user_id: DataTypes.INTEGER,
+            group_id: DataTypes.INTEGER,
+            permissions: DataTypes.ENUM('admin', 'member')
+          });
+
+          beforeEach(async () => {
+            await Memberships.sync({ force: true });
+
+            await current.queryInterface.addConstraint('memberships', {
+              type: 'UNIQUE',
+              fields: ['user_id', 'group_id']
+            });
+          });
+
+          it('should insert with no other rows', async () => {
+            const [newRow] = await Memberships.upsert(
+              {
+                user_id: 1,
+                group_id: 1,
+                permissions: 'member'
+              },
+              {
+                conflictFields: ['user_id', 'group_id']
+              }
+            );
+
+            expect(newRow).to.not.eq(null);
+            expect(newRow.permissions).to.eq('member');
+          });
+
+          it('should use conflictFields as upsertKeys', async () => {
+            const [originalMembership] = await Memberships.upsert(
+              {
+                user_id: 1,
+                group_id: 1,
+                permissions: 'member'
+              },
+              {
+                conflictFields: ['user_id', 'group_id']
+              }
+            );
+
+            expect(originalMembership).to.not.eq(null);
+            expect(originalMembership.permissions).to.eq('member');
+
+            const [updatedMembership] = await Memberships.upsert(
+              {
+                user_id: 1,
+                group_id: 1,
+                permissions: 'admin'
+              },
+              {
+                conflictFields: ['user_id', 'group_id']
+              }
+            );
+
+            expect(updatedMembership).to.not.eq(null);
+            expect(updatedMembership.permissions).to.eq('admin');
+            expect(updatedMembership.id).to.eq(originalMembership.id);
+
+            const [otherMembership] = await Memberships.upsert(
+              {
+                user_id: 2,
+                group_id: 1,
+                permissions: 'member'
+              },
+              {
+                conflictFields: ['user_id', 'group_id']
+              }
+            );
+
+            expect(otherMembership).to.not.eq(null);
+            expect(otherMembership.permissions).to.eq('member');
+            expect(otherMembership.id).to.not.eq(originalMembership.id);
+          });
+        });
+
         describe('conflictWhere', () => {
           const Users = current.define(
             'users',

--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -737,6 +737,11 @@ export interface UpsertOptions<TAttributes = any> extends Logging, Transactionab
    * Only supported in Postgres >= 9.5 and SQLite >= 3.24.0
    */
    conflictWhere?: WhereOptions<TAttributes>;
+   /**
+   * Optional override for the conflict fields in the ON CONFLICT part of the query.
+   * Only supported in Postgres >= 9.5 and SQLite >= 3.24.0
+  */
+  conflictFields?: (keyof TAttributes)[]
 }
 
 /**

--- a/types/test/upsert.ts
+++ b/types/test/upsert.ts
@@ -47,6 +47,7 @@ sequelize.transaction(async trx => {
     conflictWhere: {
       foo: "abc",
       bar: "def"
-    }
+    },
+    conflictFields: ['foo', 'bar']
   });
 })


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

Turns out that we do need this, since the logic isn't smart enough to pick up unique indexes with multiple keys. 

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

Allows for the override of the `upsertKeys` value passed to the query generator via `options.conflictFields` (for `Model.upsert`).

Note that the different name is intentional - `upsertKeys` isn't as clear as `conflictFields` IMO.

This is needed since I don't think there's any safe way to ensure that the default inference for `upsert` will always work.

Example use case (using a many:many joiner table)
```ts
const Memberships: typeof Model = sequelize.define(
  'my_joiner_table',
  {
    id: {
      primaryKey: true,
      autoIncrement: true,
      type: DataTypes.INTEGER,
      allowNull: false,
    },
    group_id: {
      type: DataTypes.INTEGER,
      primaryKey: true,
      allowNull: false,
      unique: 'my_constraint',
    },
    user_id: {
      type: DataTypes.INTEGER,
      primaryKey: true,
      allowNull: false,
      unique: 'my_constraint',
    },
  },
  { timestamps: true }
);

// In usage
await Memberships.upsert(
  {
    group_id: 5,
    team_id: 3,
  },
  {
    conflictFields: ['group_id', 'user_id'],
  }
); // `ON CONFLICT ("group_id", "user_id")` instead of `ON CONFLICT ("group_id")` 
```
